### PR TITLE
Update bdd-tests.yml

### DIFF
--- a/.github/workflows/bdd-tests.yml
+++ b/.github/workflows/bdd-tests.yml
@@ -37,6 +37,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+             node-version: '16'
+      
 
       - name: Install OS dependencies
         run: |


### PR DESCRIPTION
the GitHub Actions workflow is currently configured to use Node.js version 12 (node12), to ensure Github Action workflow  uses Node.js version 16, as bdd testing was showing-Process completed with exit code 1 and The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/.